### PR TITLE
luigi 3.5.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/python-daemon-feedstock/pr2/9e3a99e

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/python-daemon-feedstock/pr2/21b7c01

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/python-daemon-feedstock/pr2/9e3a99e
+  - https://staging.continuum.io/prefect/fs/python-daemon-feedstock/pr2/21b7c01

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: true  # [py<35 or s390x or win]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-build-isolation
   entry_points:
     - luigi = luigi.cmdline:luigi_run
     - luigid = luigi.cmdline:luigid

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,12 @@
-{% set version = "3.2.0" %}
+{% set version = "3.5.2" %}
 
 package:
   name: luigi
   version: {{ version }}
 
 source:
-  url: https://github.com/spotify/luigi/archive/{{ version }}.tar.gz
-  sha256: c8e48d48338f73fd1071654988cdc1725fc13b6b9b9c2f7532241e11994a420b
+  url: https://github.com/spotify/luigi/archive/v{{ version }}.tar.gz
+  sha256: 5e26b4ec1170248ca77d8cd497835c9dc63586967b1bbaacb4400c311129623e
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4682](https://anaconda.atlassian.net/browse/PKG-4682)
- [Upstream repository](https://github.com/spotify/luigi/tree/v3.5.2)
- [Upstream changelog/diff](https://github.com/spotify/luigi/releases)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/python-daemon-feedstock/pull/2

### Explanation of changes:

- Update version, sha256, and source url


[PKG-4682]: https://anaconda.atlassian.net/browse/PKG-4682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ